### PR TITLE
Added beneficiary name and address

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ $document = (new bsqr\model\Pay())
 		// ->setOriginatorsReferenceInformation("Originators Reference Information")
 		// ->setDirectDebitExt( /* Direct Debit Extension */ )
 		// ->setStandingOrderExt( /* Standing Order Extension */ )
+		// ->setBeneficiaryName("Beneficiary name")
+		// ->setBeneficiaryAddressLine1("Address 1")
+		// ->setBeneficiaryAddressLine2("Address 2")
 	)
 	->addPayment( /* 2nd payment */ )
 	->addPayment( /* 3rd payment */ );
@@ -92,6 +95,5 @@ $document = $bsqrCoder->parse($bsqrData);
 
 ## Links
 
-- https://www.sbaonline.sk/projekt/projekty-z-oblasti-platobnych-sluzieb/
-- https://bsqr.co/schema/
+- http://www.sbaonline.sk/sk/projekty/qr-platby/podmienky-pouzitia-specifikacia-standardu-pay-square.html
 - http://www.bysquare.com/

--- a/src/model/Payment.php
+++ b/src/model/Payment.php
@@ -34,6 +34,12 @@ class Payment extends Element {
 	public $standingOrderExt;
 	/** @var DirectDebitExt|null - Direct debit extension. Extends basic payment information with information required for identification and setup of direct debit. */
 	public $directDebitExt;
+	/** @var string|NULL - Beneficiary name  */
+	public $beneficiaryName;
+	/** @var string|NULL - Beneficiary address line 1 */
+	public $beneficiaryAddressLine1;
+	/** @var string|NULL - Beneficiary address line 2 */
+	public $beneficiaryAddressLine2;
 
 
 	/**
@@ -205,6 +211,41 @@ class Payment extends Element {
 	 */
 	public function setDirectDebitExt($directDebitExt) {
 		$this->directDebitExt = $directDebitExt;
+		return $this;
+	}
+
+	/**
+	 * Set beneficiary name
+	 *
+	 * @param string|null $beneficiaryName
+	 * @return static
+	 */
+	public function setBeneficiaryName($beneficiaryName): self
+	{
+		$this->beneficiaryName = $beneficiaryName;
+		return $this;
+	}
+
+	/**
+	 * Set beneficiary address line 1
+	 *
+	 * @param string|null $beneficiaryAddressLine1
+	 * @return static
+	 */
+	public function setBeneficiaryAddressLine1($beneficiaryAddressLine1): self
+	{
+		$this->beneficiaryAddressLine1 = $beneficiaryAddressLine1;
+		return $this;
+	}
+
+	/**
+	 * Set beneficiary address line 2
+	 * @param string|null $beneficiaryAddressLine2
+	 * @return static
+	 */
+	public function setBeneficiaryAddressLine2($beneficiaryAddressLine2): self
+	{
+		$this->beneficiaryAddressLine2 = $beneficiaryAddressLine2;
 		return $this;
 	}
 

--- a/src/utils/ClientDataEncoder.php
+++ b/src/utils/ClientDataEncoder.php
@@ -134,6 +134,10 @@ class ClientDataEncoder {
 		if ($payment->directDebitExt) {
 			$values[] = $this->encodeDirectDebitExt($payment->directDebitExt);
 		}
+		$values[] = $this->encodeValue($payment->beneficiaryName);
+		$values[] = $this->encodeValue($payment->beneficiaryAddressLine1);
+		$values[] = $this->encodeValue($payment->beneficiaryAddressLine2);
+
 		return implode($this->separator, $values);
 	}
 


### PR DESCRIPTION
QR code is missing beneficiary name and address line 1 and 2. I've made a pull-request adding this properties to the Payment and QR code generation.